### PR TITLE
refactor: add kotlin-byte-buf-serializer dependency and update packet…

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ zstd-jni = "1.5.6-9"
 luckperms-api = "5.4"
 reactive-streams = "1.0.4"
 ehcache = "3.10.8"
+kotlin-byte-buf-serializer = "1.0.0"
 
 
 [libraries]
@@ -65,6 +66,7 @@ spring-aspects = { module = "org.springframework:spring-aspects" }
 flyway-core = { module = "org.flywaydb:flyway-core" }
 flyway-mysql = { module = "org.flywaydb:flyway-mysql" }
 spring-instrument = { module = "org.springframework:spring-instrument" }
+kotlin-byte-buf-serializer = { module = "dev.slne.surf:kotlin-byte-buf-serializer", version.ref = "kotlin-byte-buf-serializer" }
 
 
 [plugins]

--- a/surf-cloud-api/surf-cloud-api-common/api/surf-cloud-api-common.api
+++ b/surf-cloud-api/surf-cloud-api-common/api/surf-cloud-api-common.api
@@ -19,6 +19,47 @@ public final class dev/slne/surf/cloud/api/common/CloudInstanceKt {
 public abstract interface annotation class dev/slne/surf/cloud/api/common/SurfCloudApplication : java/lang/annotation/Annotation {
 }
 
+public final class dev/slne/surf/cloud/api/common/TestPacket : dev/slne/surf/cloud/api/common/netty/packet/NettyPacket {
+	public static final field Companion Ldev/slne/surf/cloud/api/common/TestPacket$Companion;
+	public fun <init> (Ljava/lang/String;IZLjava/util/List;Ljava/util/Map;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()Z
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;IZLjava/util/List;Ljava/util/Map;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Ldev/slne/surf/cloud/api/common/TestPacket;
+	public static synthetic fun copy$default (Ldev/slne/surf/cloud/api/common/TestPacket;Ljava/lang/String;IZLjava/util/List;Ljava/util/Map;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Ldev/slne/surf/cloud/api/common/TestPacket;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBoolean ()Z
+	public final fun getData ()Ljava/lang/String;
+	public final fun getList ()Ljava/util/List;
+	public final fun getMap ()Ljava/util/Map;
+	public final fun getNullable ()Ljava/lang/String;
+	public final fun getNullableList ()Ljava/util/List;
+	public final fun getNullableMap ()Ljava/util/Map;
+	public final fun getNumber ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class dev/slne/surf/cloud/api/common/TestPacket$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/slne/surf/cloud/api/common/TestPacket$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/slne/surf/cloud/api/common/TestPacket;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/slne/surf/cloud/api/common/TestPacket;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class dev/slne/surf/cloud/api/common/TestPacket$Companion {
+	public final fun random ()Ldev/slne/surf/cloud/api/common/TestPacket;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public class dev/slne/surf/cloud/api/common/config/auto/AdventureAutoConfiguration {
 	public fun <init> ()V
 	public fun miniMessage ()Lnet/kyori/adventure/text/minimessage/MiniMessage;

--- a/surf-cloud-api/surf-cloud-api-common/build.gradle.kts
+++ b/surf-cloud-api/surf-cloud-api-common/build.gradle.kts
@@ -10,6 +10,10 @@ dependencies {
 
     api(libs.aide.reflection)
     api(libs.netty.all)
+    api(libs.kotlin.byte.buf.serializer) {
+        exclude(group = "io.netty")
+    }
+
     api(libs.nbt)
     api(libs.datafixerupper) {
         isTransitive = false

--- a/surf-cloud-api/surf-cloud-api-common/src/main/kotlin/dev/slne/surf/cloud/api/common/TestPacket.kt
+++ b/surf-cloud-api/surf-cloud-api-common/src/main/kotlin/dev/slne/surf/cloud/api/common/TestPacket.kt
@@ -1,0 +1,32 @@
+package dev.slne.surf.cloud.api.common
+
+import dev.slne.surf.cloud.api.common.meta.SurfNettyPacket
+import dev.slne.surf.cloud.api.common.netty.network.protocol.PacketFlow
+import dev.slne.surf.cloud.api.common.netty.packet.NettyPacket
+import kotlinx.serialization.Serializable
+
+@Serializable
+@SurfNettyPacket("cloud:serverbound:test", PacketFlow.SERVERBOUND)
+data class TestPacket(
+    val data: String,
+    val number: Int,
+    val boolean: Boolean,
+    val list: List<String>,
+    val map: Map<String, String>,
+    val nullable: String?,
+    val nullableList: List<String>?,
+    val nullableMap: Map<String, String>?,
+) : NettyPacket() {
+    companion object {
+        fun random() = TestPacket(
+            data = "test",
+            number = 42,
+            boolean = true,
+            list = listOf("one", "two", "three"),
+            map = mapOf("key1" to "value1", "key2" to "value2"),
+            nullable = null,
+            nullableList = null,
+            nullableMap = null
+        )
+    }
+}

--- a/surf-cloud-bukkit/src/main/kotlin/dev/slne/surf/cloud/bukkit/BukkitMain.kt
+++ b/surf-cloud-bukkit/src/main/kotlin/dev/slne/surf/cloud/bukkit/BukkitMain.kt
@@ -6,7 +6,9 @@ import com.github.shynixn.mccoroutine.folia.launch
 import com.github.shynixn.mccoroutine.folia.ticks
 import dev.jorel.commandapi.CommandAPIBukkit
 import dev.jorel.commandapi.kotlindsl.*
+import dev.slne.surf.cloud.api.client.netty.packet.fireAndForget
 import dev.slne.surf.cloud.api.client.paper.player.toCloudOfflinePlayer
+import dev.slne.surf.cloud.api.common.TestPacket
 import dev.slne.surf.cloud.api.common.player.teleport.TeleportCause
 import dev.slne.surf.cloud.api.common.player.teleport.fineLocation
 import dev.slne.surf.cloud.api.common.player.toCloudPlayer
@@ -268,6 +270,13 @@ class BukkitMain : SuspendingJavaPlugin() {
                         }
                     }
                 }
+            }
+        }
+
+        commandAPICommand("send-test-packet") {
+            anyExecutor { sender, args ->
+                TestPacket.random().fireAndForget()
+                sender.sendPlainMessage("Test packet sent")
             }
         }
     }

--- a/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/test/TestPacketListener.kt
+++ b/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/test/TestPacketListener.kt
@@ -1,5 +1,7 @@
 package dev.slne.surf.cloud.standalone.test
 
+import dev.slne.surf.cloud.api.common.TestPacket
+import dev.slne.surf.cloud.api.common.meta.SurfNettyPacketHandler
 import dev.slne.surf.surfapi.core.api.util.logger
 import org.springframework.stereotype.Component
 
@@ -7,4 +9,10 @@ import org.springframework.stereotype.Component
 @Component
 class TestPacketListener {
     private val log = logger()
+
+    @SurfNettyPacketHandler
+    fun onTestPacket(packet: TestPacket) {
+        log.atInfo()
+            .log("Received TestPacket: $packet")
+    }
 }


### PR DESCRIPTION
This pull request introduces a new `TestPacket` class and integrates it into various parts of the project. The changes include adding dependencies, creating the `TestPacket` class, updating build files, and adding handling and sending capabilities for the new packet.

### New `TestPacket` class and related integrations:

* **Creation of `TestPacket` class:**
  - Added `TestPacket` class with various fields and methods in `surf-cloud-api/surf-cloud-api-common/api/surf-cloud-api-common.api`.
  - Implemented `TestPacket` class in Kotlin with serialization and companion object methods in `surf-cloud-api/surf-cloud-api-common/src/main/kotlin/dev/slne/surf/cloud/api/common/TestPacket.kt`.

* **Dependency updates:**
  - Added `kotlin-byte-buf-serializer` dependency in `gradle/libs.versions.toml`. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR20) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR69)
  - Included `kotlin-byte-buf-serializer` in `surf-cloud-api/surf-cloud-api-common/build.gradle.kts` with an exclusion for `io.netty`.

* **Packet handling and sending:**
  - Updated `packet-extension.kt` to support serialization and deserialization of `TestPacket` using `Buf`. [[1]](diffhunk://#diff-70cb9599a8dcb27254e67b160922d09dd70e56f45647e33c0185057412b04607R3-R13) [[2]](diffhunk://#diff-70cb9599a8dcb27254e67b160922d09dd70e56f45647e33c0185057412b04607R76-R93)
  - Added command to send `TestPacket` in `BukkitMain.kt` and imported necessary classes. [[1]](diffhunk://#diff-a981a1a32b3542b7df761085940680e4be8170bc51112d5cc95660758e7162cbR9-R11) [[2]](diffhunk://#diff-a981a1a32b3542b7df761085940680e4be8170bc51112d5cc95660758e7162cbR275-R281)
  - Created a listener for `TestPacket` in `TestPacketListener.kt` to log received packets.