### PR TITLE
refactor: update Netty version and organize dependencies in build configuration

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,8 @@
 [versions]
 velocity-version = "3.4.0-SNAPSHOT"
 aide-reflection = "1.3"
-netty = "4.1.117.Final"
+netty = "4.2.0.Final"
+netty-tcnative = "2.0.70.Final"
 nbt = "6.1"
 datafixerupper = "8.0.16"
 byte-buddy = "1.15.10"
@@ -29,6 +30,7 @@ jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind" }
 jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin" }
 aide-reflection = { module = "tech.hiddenproject:aide-reflection", version.ref = "aide-reflection" }
 netty-all = { module = "io.netty:netty-all", version.ref = "netty" }
+netty-tcnative = { module = "io.netty:netty-tcnative", version.ref = "netty-tcnative" }
 nbt = { module = "com.github.Querz:NBT", version.ref = "nbt" }
 spring-data-jpa = { module = "org.springframework.data:spring-data-jpa" }
 datafixerupper = { module = "com.mojang:datafixerupper", version.ref = "datafixerupper" }
@@ -73,6 +75,7 @@ kotlin-byte-buf-serializer = { module = "dev.slne.surf:kotlin-byte-buf-serialize
 spring-boot = { id = "org.springframework.boot" }
 
 [bundles]
+netty-all = ["netty-all", "netty-tcnative"]
 spring-aop = ["spring-aop", "aspectjweaver", "aspectjrt", "spring-aspects"]
 spring-api-common = ["spring-boot-starter", "spring-boot-starter-cache"]
 jackson-api-common = ["jackson-core", "jackson-databind", "jackson-module-kotlin"]

--- a/surf-cloud-api/surf-cloud-api-common/build.gradle.kts
+++ b/surf-cloud-api/surf-cloud-api-common/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
     api(libs.bundles.spring.aop)
 
     api(libs.aide.reflection)
-    api(libs.netty.all)
+    api(libs.bundles.netty.all)
     api(libs.kotlin.byte.buf.serializer) {
         exclude(group = "io.netty")
     }

--- a/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/netty/server/network/ServerEncryptionManager.kt
+++ b/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/netty/server/network/ServerEncryptionManager.kt
@@ -2,7 +2,6 @@ package dev.slne.surf.cloud.standalone.netty.server.network
 
 import dev.slne.surf.cloud.core.common.netty.network.EncryptionManager
 import dev.slne.surf.cloud.core.common.netty.network.HandlerNames
-import dev.slne.surf.surfapi.core.api.util.logger
 import io.netty.channel.Channel
 import io.netty.handler.ssl.ClientAuth
 import io.netty.handler.ssl.SslContext
@@ -12,8 +11,6 @@ import java.security.cert.CertificateFactory
 import javax.net.ssl.TrustManagerFactory
 
 object ServerEncryptionManager : EncryptionManager() {
-    private val log = logger()
-
     private val serverCertificateFile = certificatesFolder.resolve("server.crt").toFile()
     private val serverKeyFile = certificatesFolder.resolve("server.key").toFile()
     private val clientCertificatesFolder =


### PR DESCRIPTION
This pull request includes several changes to update dependencies, refactor code, and improve the project structure. The most important changes include updating the Netty version, adding a new Netty module, and refactoring how dependencies are bundled and imported.

Dependency updates and additions:

* Updated `netty` version from `4.1.117.Final` to `4.2.0.Final` and added `netty-tcnative` version `2.0.70.Final` in `gradle/libs.versions.toml`.
* Added `netty-tcnative` module reference in `gradle/libs.versions.toml`.

Dependency bundling:

* Added `netty-all` bundle to include both `netty-all` and `netty-tcnative` in `gradle/libs.versions.toml`.
* Updated `surf-cloud-api/surf-cloud-api-common/build.gradle.kts` to use the new `netty-all` bundle instead of individual `netty` dependencies.

Code refactoring:

* Removed unused import `logger` from `ServerEncryptionManager.kt`. [[1]](diffhunk://#diff-c3f56a9dc7fe3640028caf2bcf325634a35b58a8f842cda0f769e4950aec48c1L5) [[2]](diffhunk://#diff-c3f56a9dc7fe3640028caf2bcf325634a35b58a8f842cda0f769e4950aec48c1L15-L16)