### PR TITLE
Add AFK Placeholder Support and State Management for Paper and Velocity

### DIFF
--- a/surf-cloud-api/surf-cloud-api-common/src/main/kotlin/dev/slne/surf/cloud/api/common/player/CloudPlayer.kt
+++ b/surf-cloud-api/surf-cloud-api-common/src/main/kotlin/dev/slne/surf/cloud/api/common/player/CloudPlayer.kt
@@ -39,7 +39,7 @@ interface CloudPlayer : Audience, OfflineCloudPlayer { // TODO: conversation but
      */
     val connected get() = connectedToProxy || connectedToServer
 
-    suspend fun isAfk(): Boolean
+    fun isAfk(): Boolean
     suspend fun currentSessionDuration(): Duration
 
     /**

--- a/surf-cloud-bukkit/src/main/kotlin/dev/slne/surf/cloud/bukkit/CloudBukkitInstance.kt
+++ b/surf-cloud-bukkit/src/main/kotlin/dev/slne/surf/cloud/bukkit/CloudBukkitInstance.kt
@@ -5,11 +5,13 @@ import dev.slne.surf.cloud.api.common.CloudInstance
 import dev.slne.surf.cloud.bukkit.command.PaperCommandManager
 import dev.slne.surf.cloud.bukkit.listener.ListenerManager
 import dev.slne.surf.cloud.bukkit.netty.BukkitNettyManager
+import dev.slne.surf.cloud.bukkit.placeholder.CloudPlaceholderExpansion
 import dev.slne.surf.cloud.bukkit.processor.BukkitListenerProcessor
 import dev.slne.surf.cloud.core.client.ClientCommonCloudInstance
 import dev.slne.surf.cloud.core.common.coreCloudInstance
 import dev.slne.surf.cloud.core.common.util.bean
 import dev.slne.surf.cloud.core.common.util.checkInstantiationByServiceLoader
+import dev.slne.surf.surfapi.bukkit.api.hook.papi.papiHook
 
 @AutoService(CloudInstance::class)
 class CloudBukkitInstance : ClientCommonCloudInstance(BukkitNettyManager) {
@@ -23,12 +25,15 @@ class CloudBukkitInstance : ClientCommonCloudInstance(BukkitNettyManager) {
         PaperCommandManager.registerCommands()
         bean<BukkitListenerProcessor>().registerListeners()
         ListenerManager.registerListeners()
+
+        papiHook.register(CloudPlaceholderExpansion)
     }
 
     override suspend fun onDisable() {
         super.onDisable()
 
         ListenerManager.unregisterListeners()
+        papiHook.unregister(CloudPlaceholderExpansion)
     }
 }
 

--- a/surf-cloud-bukkit/src/main/kotlin/dev/slne/surf/cloud/bukkit/listener/player/PlayerAfkListener.kt
+++ b/surf-cloud-bukkit/src/main/kotlin/dev/slne/surf/cloud/bukkit/listener/player/PlayerAfkListener.kt
@@ -1,7 +1,7 @@
 package dev.slne.surf.cloud.bukkit.listener.player
 
 import dev.slne.surf.cloud.api.client.netty.packet.fireAndForget
-import dev.slne.surf.cloud.core.common.netty.network.protocol.running.ServerboundUpdateAFKState
+import dev.slne.surf.cloud.core.common.netty.network.protocol.running.UpdateAFKStatePacket
 import dev.slne.surf.surfapi.core.api.util.mutableObject2BooleanMapOf
 import dev.slne.surf.surfapi.core.api.util.mutableObject2LongMapOf
 import org.bukkit.event.EventHandler
@@ -57,6 +57,6 @@ class PlayerAfkListener : Listener {
     }
 
     private fun broadcastChange(uuid: UUID, isAfk: Boolean) {
-        ServerboundUpdateAFKState(uuid, isAfk).fireAndForget()
+        UpdateAFKStatePacket(uuid, isAfk).fireAndForget()
     }
 }

--- a/surf-cloud-bukkit/src/main/kotlin/dev/slne/surf/cloud/bukkit/placeholder/CloudPlaceholderExpansion.kt
+++ b/surf-cloud-bukkit/src/main/kotlin/dev/slne/surf/cloud/bukkit/placeholder/CloudPlaceholderExpansion.kt
@@ -1,0 +1,10 @@
+package dev.slne.surf.cloud.bukkit.placeholder
+
+import dev.slne.surf.cloud.api.common.util.objectListOf
+import dev.slne.surf.cloud.bukkit.placeholder.afk.CloudAfkPlaceholder
+import dev.slne.surf.surfapi.bukkit.api.hook.papi.expansion.PapiExpansion
+
+object CloudPlaceholderExpansion : PapiExpansion(
+    "cloud",
+    objectListOf(CloudAfkPlaceholder)
+)

--- a/surf-cloud-bukkit/src/main/kotlin/dev/slne/surf/cloud/bukkit/placeholder/afk/CloudAfkPlaceholder.kt
+++ b/surf-cloud-bukkit/src/main/kotlin/dev/slne/surf/cloud/bukkit/placeholder/afk/CloudAfkPlaceholder.kt
@@ -1,0 +1,28 @@
+package dev.slne.surf.cloud.bukkit.placeholder.afk
+
+import dev.slne.surf.cloud.api.common.player.CloudPlayerManager
+import dev.slne.surf.surfapi.bukkit.api.hook.papi.expansion.PapiPlaceholder
+import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
+import org.bukkit.OfflinePlayer
+
+object CloudAfkPlaceholder : PapiPlaceholder("afk") {
+    private const val NOT_AFK_STRING = ""
+    private val afkString = LegacyComponentSerializer.legacySection().serialize(buildText {
+        spacer("[")
+        text("💤")
+        spacer("]")
+    })
+
+    override fun parse(
+        player: OfflinePlayer,
+        args: List<String>
+    ): String? {
+        val cloudPlayer = CloudPlayerManager.getPlayer(player.uniqueId) ?: return null
+        if (!cloudPlayer.isAfk()) {
+            return NOT_AFK_STRING
+        }
+
+        return afkString
+    }
+}

--- a/surf-cloud-core/surf-cloud-core-client/src/main/kotlin/dev/slne/surf/cloud/core/client/netty/network/ClientRunningPacketListenerImpl.kt
+++ b/surf-cloud-core/surf-cloud-core-client/src/main/kotlin/dev/slne/surf/cloud/core/client/netty/network/ClientRunningPacketListenerImpl.kt
@@ -6,6 +6,7 @@ import dev.slne.surf.cloud.api.common.netty.packet.NettyPacket
 import dev.slne.surf.cloud.api.common.netty.packet.NettyPacketInfo
 import dev.slne.surf.cloud.api.common.server.UserListImpl
 import dev.slne.surf.cloud.core.client.netty.ClientNettyClientImpl
+import dev.slne.surf.cloud.core.client.player.ClientCloudPlayerImpl
 import dev.slne.surf.cloud.core.client.player.commonPlayerManagerImpl
 import dev.slne.surf.cloud.core.client.server.serverManagerImpl
 import dev.slne.surf.cloud.core.client.util.getOrLoadUser
@@ -245,6 +246,13 @@ class ClientRunningPacketListenerImpl(
                 CloudServerImpl(it.serverId, it.group, it.name)
             }
         })
+    }
+
+    override fun handleUpdateAFKState(packet: UpdateAFKStatePacket) {
+        playerManagerImpl.getPlayer(packet.uuid)?.let { player ->
+            require(player is ClientCloudPlayerImpl<*>) { "Player $player is not a client player" }
+            player.afk = packet.isAfk
+        }
     }
 
     override fun handlePacket(packet: NettyPacket) {

--- a/surf-cloud-core/surf-cloud-core-client/src/main/kotlin/dev/slne/surf/cloud/core/client/player/ClientCloudPlayerImpl.kt
+++ b/surf-cloud-core/surf-cloud-core-client/src/main/kotlin/dev/slne/surf/cloud/core/client/player/ClientCloudPlayerImpl.kt
@@ -49,6 +49,10 @@ abstract class ClientCloudPlayerImpl<PlatformPlayer : Audience>(uuid: UUID, name
 
     @Volatile
     var serverUid: Long? = null
+
+    @Volatile
+    var afk: Boolean = false
+
     override val connectedToProxy get() = proxyServerUid != null
 
     override val connectedToServer get() = serverUid != null
@@ -76,8 +80,8 @@ abstract class ClientCloudPlayerImpl<PlatformPlayer : Audience>(uuid: UUID, name
         return request<FirstSeen>(DataRequestType.FIRST_SEEN).firstSeen
     }
 
-    override suspend fun isAfk(): Boolean {
-        return request<IsAFK>(DataRequestType.IS_AFK).isAfk
+    override fun isAfk(): Boolean {
+        return afk
     }
 
     override suspend fun currentSessionDuration(): Duration {

--- a/surf-cloud-core/surf-cloud-core-common/src/main/kotlin/dev/slne/surf/cloud/core/common/netty/network/ConnectionImpl.kt
+++ b/surf-cloud-core/surf-cloud-core-common/src/main/kotlin/dev/slne/surf/cloud/core/common/netty/network/ConnectionImpl.kt
@@ -345,7 +345,7 @@ class ConnectionImpl(
                         is TeleportPlayerToPlayerPacket -> listener.handleTeleportPlayerToPlayer(msg)
                         is ServerboundShutdownServerPacket -> listener.handleShutdownServer(msg)
                         is ServerboundRequestPlayerDataPacket -> listener.handleRequestPlayerData(msg)
-                        is ServerboundUpdateAFKState -> listener.handleUpdateAFKState(msg)
+                        is UpdateAFKStatePacket -> listener.handleUpdateAFKState(msg)
 
                         else -> listener.handlePacket(msg) // handle other packets
                     }
@@ -471,6 +471,7 @@ class ConnectionImpl(
                         )
                         is ClientboundTriggerShutdownPacket -> listener.handleTriggerShutdown(msg)
                         is ClientboundBatchUpdateServer -> listener.handleBatchUpdateServer(msg)
+                        is UpdateAFKStatePacket -> listener.handleUpdateAFKState(msg)
 
                         else -> listener.handlePacket(msg)
                     }

--- a/surf-cloud-core/surf-cloud-core-common/src/main/kotlin/dev/slne/surf/cloud/core/common/netty/network/protocol/running/RunningClientPacketListener.kt
+++ b/surf-cloud-core/surf-cloud-core-common/src/main/kotlin/dev/slne/surf/cloud/core/common/netty/network/protocol/running/RunningClientPacketListener.kt
@@ -75,5 +75,7 @@ interface RunningClientPacketListener : ClientCommonPacketListener {
 
     suspend fun handleBatchUpdateServer(packet: ClientboundBatchUpdateServer)
 
+    fun handleUpdateAFKState(packet: UpdateAFKStatePacket)
+
     fun handlePacket(packet: NettyPacket)
 }

--- a/surf-cloud-core/surf-cloud-core-common/src/main/kotlin/dev/slne/surf/cloud/core/common/netty/network/protocol/running/RunningProtocols.kt
+++ b/surf-cloud-core/surf-cloud-core-common/src/main/kotlin/dev/slne/surf/cloud/core/common/netty/network/protocol/running/RunningProtocols.kt
@@ -2,7 +2,6 @@ package dev.slne.surf.cloud.core.common.netty.network.protocol.running
 
 import dev.slne.surf.cloud.api.common.netty.network.ConnectionProtocol
 import dev.slne.surf.cloud.api.common.netty.packet.createCodec
-import dev.slne.surf.cloud.api.common.netty.packet.findPacketCodec
 import dev.slne.surf.cloud.api.common.netty.protocol.buffer.SurfByteBuf
 import dev.slne.surf.cloud.core.common.netty.network.protocol.ProtocolInfoBuilder
 import dev.slne.surf.cloud.core.common.netty.network.protocol.common.*
@@ -56,6 +55,7 @@ object RunningProtocols {
                 .addPacket(PullPlayersToGroupResponsePacket::class.createCodec())
                 .addPacket(SilentDisconnectPlayerPacket::class.createCodec())
                 .addPacket(TeleportPlayerToPlayerPacket::class.createCodec())
+                .addPacket(UpdateAFKStatePacket::class.createCodec())
         }
 
     val CLIENTBOUND by lazy { CLIENTBOUND_TEMPLATE.freeze().bind(::SurfByteBuf) }
@@ -100,7 +100,7 @@ object RunningProtocols {
                 .addPacket(ServerboundShutdownServerPacket.STREAM_CODEC)
                 .addPacket(RequestOfflineDisplayNamePacket.STREAM_CODEC)
                 .addPacket(ServerboundRequestPlayerDataPacket.STREAM_CODEC)
-                .addPacket(ServerboundUpdateAFKState::class.createCodec())
+                .addPacket(UpdateAFKStatePacket::class.createCodec())
                 .addPacket(ServerboundPullPlayersToGroupPacket::class.createCodec())
                 .addPacket(SilentDisconnectPlayerPacket::class.createCodec())
                 .addPacket(TeleportPlayerToPlayerPacket::class.createCodec())

--- a/surf-cloud-core/surf-cloud-core-common/src/main/kotlin/dev/slne/surf/cloud/core/common/netty/network/protocol/running/RunningServerPacketListener.kt
+++ b/surf-cloud-core/surf-cloud-core-common/src/main/kotlin/dev/slne/surf/cloud/core/common/netty/network/protocol/running/RunningServerPacketListener.kt
@@ -68,7 +68,7 @@ interface RunningServerPacketListener : ServerCommonPacketListener, TickablePack
 
     suspend fun handleRequestPlayerData(packet: ServerboundRequestPlayerDataPacket)
 
-    fun handleUpdateAFKState(packet: ServerboundUpdateAFKState)
+    fun handleUpdateAFKState(packet: UpdateAFKStatePacket)
     
     fun handlePacket(packet: NettyPacket)
 }

--- a/surf-cloud-core/surf-cloud-core-common/src/main/kotlin/dev/slne/surf/cloud/core/common/netty/network/protocol/running/UpdateAFKStatePacket.kt
+++ b/surf-cloud-core/surf-cloud-core-common/src/main/kotlin/dev/slne/surf/cloud/core/common/netty/network/protocol/running/UpdateAFKStatePacket.kt
@@ -7,6 +7,6 @@ import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 import java.util.*
 
-@SurfNettyPacket("cloud:serverbound:update_afk_state", PacketFlow.SERVERBOUND)
+@SurfNettyPacket("cloud:bidirectional:update_afk_state", PacketFlow.BIDIRECTIONAL)
 @Serializable
-class ServerboundUpdateAFKState(val uuid: @Contextual UUID, val isAfk: Boolean) : NettyPacket()
+class UpdateAFKStatePacket(val uuid: @Contextual UUID, val isAfk: Boolean) : NettyPacket()

--- a/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/netty/server/network/ServerRunningPacketListenerImpl.kt
+++ b/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/netty/server/network/ServerRunningPacketListenerImpl.kt
@@ -296,7 +296,7 @@ class ServerRunningPacketListenerImpl(
         )
     }
 
-    override fun handleUpdateAFKState(packet: ServerboundUpdateAFKState) {
+    override fun handleUpdateAFKState(packet: UpdateAFKStatePacket) {
         withPlayer(packet.uuid) { updateAfkStatus(packet.isAfk) }
     }
 


### PR DESCRIPTION
### Overview of Changes
This PR introduces support for an AFK (Away From Keyboard) placeholder in Paper and Velocity environments, along with full AFK state tracking and packet handling. The changes enable dynamic updates to a player's AFK status across the network and provide visual feedback using placeholders.

### Details
- **Feature: Placeholder Support for AFK State**
  - Added `CloudPlaceholderExpansion` and `CloudAfkPlaceholder` classes for PlaceholderAPI (PAPI) integration.
  - Registered and unregistered AFK placeholder expansion during plugin enable/disable in `CloudBukkitInstance`.

- **Feature: AFK State Management and Propagation**
  - Introduced `UpdateAFKStatePacket`, a bidirectional packet replacing `ServerboundUpdateAFKState`, to streamline AFK state communication.
  - Updated `ClientRunningPacketListenerImpl`, `ServerRunningPacketListenerImpl`, and other related classes to handle the new packet.
  - Broadcast AFK state changes in `StandaloneCloudPlayerImpl`.

- **Refactor: AFK API Updates**
  - Changed `isAfk()` from a suspend function to a synchronous call across implementations for consistency.
  - Updated related classes including `CloudPlayer`, `ClientCloudPlayerImpl`, and `StandaloneCloudPlayerImpl`.

- **Miscellaneous: Protocol and Connection Adjustments**
  - Registered `UpdateAFKStatePacket` in protocol bindings.
  - Modified packet routing logic in `ConnectionImpl`.

### Motivation
The AFK state is a valuable part of player monitoring and server experience. This change enhances player awareness and administrative tools by introducing reliable AFK detection and cross-platform placeholder support.

### Impact
- **User Experience**: Players and admins can now easily identify AFK players via in-game tags.
- **Developer Experience**: Simplified AFK status handling with improved API and packet structure.
- **Performance**: Minimal overhead due to the lightweight design of packet handling and placeholder parsing.

### Testing
- Verified AFK placeholder updates correctly when toggling AFK status.
- Confirmed bidirectional packet flow across server-client architecture.
- Ensured no regressions in placeholder registration and listener logic.

### Additional Notes
- Packet was renamed and restructured to be bidirectional, ensuring real-time state sync.
- Legacy references to `ServerboundUpdateAFKState` were removed and replaced.
- Closes #33 