### PR TITLE
Add TimeLogger for boot performance tracking and fix shutdown hang in standalone mode

### DIFF
--- a/surf-cloud-api/surf-cloud-api-common/src/main/kotlin/dev/slne/surf/cloud/api/common/util/TimeLogger.kt
+++ b/surf-cloud-api/surf-cloud-api-common/src/main/kotlin/dev/slne/surf/cloud/api/common/util/TimeLogger.kt
@@ -1,0 +1,38 @@
+package dev.slne.surf.cloud.api.common.util
+
+import net.kyori.adventure.text.logger.slf4j.ComponentLogger
+import org.springframework.util.StopWatch
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+class TimeLogger(private val label: String) {
+    @PublishedApi
+    internal val logger = ComponentLogger.logger(label)
+
+    @PublishedApi
+    internal val stopWatch = StopWatch(label)
+
+    @PublishedApi
+    internal val taskCounter = AtomicInteger()
+
+    @PublishedApi
+    internal val taskNames = ConcurrentHashMap<Int, String>()
+
+    inline fun <T> measureStep(name: String, block: () -> T): T {
+        val index = taskCounter.incrementAndGet()
+        taskNames[index] = name
+        logger.info("▶️  Step $index: $name started...")
+        stopWatch.start("Step $index: $name")
+        val result = block()
+        stopWatch.stop()
+        logger.info("✅ Step $index: $name completed in %.2fs".format(stopWatch.lastTaskInfo().timeSeconds))
+        return result
+    }
+
+    fun printSummary() {
+        logger.info("⏱️  Total Time: %.2fs".format(stopWatch.totalTimeSeconds))
+        logger.info(stopWatch.prettyPrint())
+    }
+
+    fun totalSeconds(): Double = stopWatch.totalTimeSeconds
+}

--- a/surf-cloud-api/surf-cloud-api-common/src/main/kotlin/dev/slne/surf/cloud/api/common/util/spring-util.kt
+++ b/surf-cloud-api/surf-cloud-api-common/src/main/kotlin/dev/slne/surf/cloud/api/common/util/spring-util.kt
@@ -58,6 +58,13 @@ inline fun Any.measureWithStopWatch(taskName: String, block: () -> Unit): StopWa
     return stopWatch
 }
 
+inline fun <R> StopWatch.measure(taskName: String, block: () -> R): R {
+    start(taskName)
+    val result = block()
+    stop()
+    return result
+}
+
 /**
  * Default dispatcher used for coroutine-based transactional execution.
  * Limits the number of concurrent transactional operations to 8,

--- a/surf-cloud-core/surf-cloud-core-client/src/main/kotlin/dev/slne/surf/cloud/core/client/ClientCommonCloudInstance.kt
+++ b/surf-cloud-core/surf-cloud-core-client/src/main/kotlin/dev/slne/surf/cloud/core/client/ClientCommonCloudInstance.kt
@@ -1,18 +1,22 @@
 package dev.slne.surf.cloud.core.client
 
+import dev.slne.surf.cloud.api.common.util.TimeLogger
+import dev.slne.surf.cloud.api.common.util.measure
 import dev.slne.surf.cloud.core.client.netty.NettyCommonClientManager
 import dev.slne.surf.cloud.core.client.netty.network.ClientEncryptionManager
 import dev.slne.surf.cloud.core.common.CloudCoreInstance
 import dev.slne.surf.cloud.core.common.netty.NettyManager
 import dev.slne.surf.cloud.core.common.netty.network.protocol.running.ServerboundShutdownServerPacket
 import dev.slne.surf.cloud.core.common.server.CommonCloudServerImpl
+import org.springframework.util.StopWatch
 
 abstract class ClientCommonCloudInstance(nettyManager: NettyManager) :
     CloudCoreInstance(nettyManager) {
 
-    override suspend fun preBootstrap() {
-        super.preBootstrap()
-        ClientEncryptionManager.init()
+    override suspend fun preBootstrap(timeLogger: TimeLogger) {
+        timeLogger.measureStep("Setup client encryption manager") {
+            ClientEncryptionManager.init()
+        }
     }
 
     override fun shutdownServer(server: CommonCloudServerImpl) {

--- a/surf-cloud-core/surf-cloud-core-common/src/main/kotlin/dev/slne/surf/cloud/core/common/coroutines/scopes.kt
+++ b/surf-cloud-core/surf-cloud-core-common/src/main/kotlin/dev/slne/surf/cloud/core/common/coroutines/scopes.kt
@@ -15,7 +15,7 @@ abstract class BaseScope(
     companion object {
         private val scopes = mutableObjectListOf<BaseScope>()
         fun terminateAll() {
-            scopes.forEach { it.cancel() }
+            scopes.forEach { it.cancel("Shutdown") }
         }
     }
 
@@ -95,11 +95,6 @@ object ServerShutdownScope : BaseScope(
         daemon(false)
     }).asCoroutineDispatcher(),
     name = "server-shutdown"
-)
-
-object ConsoleCommandHandlerScope : BaseScope(
-    dispatcher = Dispatchers.IO,
-    name = "console-command-handler"
 )
 
 object ConsoleCommandInputScope : BaseScope(

--- a/surf-cloud-core/surf-cloud-core-common/src/main/kotlin/dev/slne/surf/cloud/core/common/netty/NettyManager.kt
+++ b/surf-cloud-core/surf-cloud-core-common/src/main/kotlin/dev/slne/surf/cloud/core/common/netty/NettyManager.kt
@@ -14,7 +14,6 @@ abstract class NettyManager {
 
     @MustBeInvokedByOverriders
     open suspend fun bootstrap() {
-        log.atInfo().log("Bootstrapping NettyManager...")
     }
 
     @MustBeInvokedByOverriders

--- a/surf-cloud-core/surf-cloud-core-common/src/main/kotlin/dev/slne/surf/cloud/core/common/processors/NettyPacketProcessor.kt
+++ b/surf-cloud-core/surf-cloud-core-common/src/main/kotlin/dev/slne/surf/cloud/core/common/processors/NettyPacketProcessor.kt
@@ -91,7 +91,7 @@ object NettyPacketProcessor : ApplicationListener<ContextRefreshedEvent> {
     }
 
     private fun logRegistration(packet: KClass<out NettyPacket>, packetMeta: SurfNettyPacket) {
-        log.atInfo()
+        log.atFine()
             .log(buildString {
                 append("Registered packet: ")
                 append(packet.simpleName)

--- a/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/Bootstrap.kt
+++ b/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/Bootstrap.kt
@@ -6,7 +6,6 @@ import dev.slne.surf.surfapi.core.api.util.logger
 import dev.slne.surf.surfapi.standalone.SurfApiStandaloneBootstrap
 import kotlinx.coroutines.runBlocking
 import org.springframework.boot.SpringApplication
-import kotlin.concurrent.thread
 import kotlin.io.path.Path
 import kotlin.system.exitProcess
 
@@ -29,16 +28,6 @@ object Bootstrap {
             )
             standaloneCloudInstance.onLoad()
             standaloneCloudInstance.onEnable()
-
-            Runtime.getRuntime().addShutdownHook(thread(start = false) {
-                runBlocking {
-                    repeat(20) {
-                        println("Running shutdown hook")
-                    }
-                    standaloneCloudInstance.onDisable()
-                    SurfApiStandaloneBootstrap.shutdown()
-                }
-            })
         } catch (e: Throwable) {
             e.handleEventuallyFatalError {
                 val context = standaloneCloudInstance.dataContext

--- a/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/commands/impl/ShutdownCommand.kt
+++ b/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/commands/impl/ShutdownCommand.kt
@@ -1,21 +1,20 @@
 package dev.slne.surf.cloud.standalone.commands.impl
 
 import com.mojang.brigadier.CommandDispatcher
-import dev.slne.surf.cloud.api.common.exceptions.ExitCodes
 import dev.slne.surf.cloud.api.server.command.CommandSource
 import dev.slne.surf.cloud.api.server.command.ConsoleCommand
 import dev.slne.surf.cloud.api.server.command.literal
-import kotlin.system.exitProcess
+import dev.slne.surf.cloud.core.common.coroutines.ServerShutdownScope
+import dev.slne.surf.cloud.standalone.standaloneCloudInstance
+import kotlinx.coroutines.launch
 
 object ShutdownCommand: ConsoleCommand {
     fun register(dispatcher: CommandDispatcher<CommandSource>) {
-        repeat(20) {
-            println("This is a fake loop")
-        }
         dispatcher.register(literal("stop") {
             executes { context ->
                 context.source.sendSuccess("Stopping standalone server...")
-                exitProcess(ExitCodes.NORMAL)
+                ServerShutdownScope.launch { standaloneCloudInstance.shutdown() }
+                1
             }
         })
     }

--- a/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/console/StandaloneConsole.kt
+++ b/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/console/StandaloneConsole.kt
@@ -1,23 +1,20 @@
 package dev.slne.surf.cloud.standalone.console
 
-import dev.slne.surf.cloud.api.common.exceptions.ExitCodes
 import dev.slne.surf.cloud.core.common.coroutines.ConsoleCommandInputScope
 import dev.slne.surf.cloud.standalone.commands.CommandManagerImpl
-import dev.slne.surf.surfapi.core.api.util.logger
 import jakarta.annotation.PostConstruct
 import kotlinx.coroutines.launch
 import net.minecrell.terminalconsole.SimpleTerminalConsole
 import org.jline.reader.LineReader
 import org.jline.reader.LineReaderBuilder
-import org.springframework.context.event.ContextClosedEvent
-import org.springframework.context.event.EventListener
+import org.springframework.beans.factory.DisposableBean
+import org.springframework.beans.factory.InitializingBean
 import org.springframework.stereotype.Component
 import kotlin.io.path.Path
-import kotlin.system.exitProcess
 
 @Component
 class StandaloneConsole(private val commandManager: CommandManagerImpl) :
-    SimpleTerminalConsole() {
+    SimpleTerminalConsole(), DisposableBean, InitializingBean {
     @Volatile
     private var running = true
 
@@ -45,19 +42,14 @@ class StandaloneConsole(private val commandManager: CommandManagerImpl) :
     }
 
     override fun shutdown() {
-        exitProcess(ExitCodes.NORMAL)
+//        exitProcess(ExitCodes.NORMAL)
     }
 
-    @Suppress("ProtectedInFinal") // IJ being dumb
-    @EventListener(ContextClosedEvent::class)
-    protected fun onContextClose() {
+    override fun destroy() {
         running = false
-        logger().atInfo().log("Shutting down console")
     }
 
-    @Suppress("ProtectedInFinal") // IJ being dumb
-    @PostConstruct
-    protected fun init() {
+    override fun afterPropertiesSet() {
         ConsoleCommandInputScope.launch {
             start()
         }

--- a/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/ktor/KtorServer.kt
+++ b/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/ktor/KtorServer.kt
@@ -15,6 +15,7 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.websocket.*
 import io.ktor.websocket.*
+import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -44,6 +45,10 @@ object KtorServer {
                 }
             }
         }.start(wait = true)
+    }
+
+    fun stop() {
+        KtorScope.coroutineContext.cancelChildren()
     }
 
     private fun StatusPagesConfig.configure() {


### PR DESCRIPTION
### Overview of Changes
This PR introduces a `TimeLogger` utility to measure and log bootstrap phase durations across client and server modes. Additionally, it resolves issues where the standalone server would hang on shutdown, requiring a manual kill.

### Details
- **Feature: Introduced `TimeLogger` for performance tracking**
  - Created `TimeLogger.kt`, a utility class leveraging `StopWatch` to track named steps and print summaries.
  - Integrated into the `CloudCoreInstance` bootstrap flow and measured key steps like encryption manager init and Netty startup.

- **Refactor: Standardized bootstrap process**
  - Replaced previous direct calls to init functions with `timeLogger.measureStep` for consistent profiling.
  - Split `bootstrap()` into clear lifecycle steps: `preBootstrap`, `bootstrap`, `onBootstrap`.

- **Bugfix: Resolved shutdown hang in standalone mode**
  - Removed `ShutdownHook` workaround.
  - Replaced manual scope management with Spring lifecycle (`InitializingBean` and `DisposableBean`) and `@Scheduled` annotation for polling.
  - Added proper coroutine cancellation for Ktor and shutdown propagation using `ServerShutdownScope`.

- **Cleanups & Miscellaneous**
  - Reduced excessive log noise (e.g., lowered packet registration log level).
  - Removed deprecated or redundant coroutine scopes and shutdown code.

### Motivation
Previously, the bootstrap phase lacked visibility into performance and sometimes caused debugging delays. Additionally, the standalone server would not shutdown gracefully, often requiring a manual `kill` due to improperly managed scopes and missing Spring integration. This PR introduces systematic profiling and ensures clean shutdown behavior.

### Impact
- **Developer experience:** Easier performance diagnostics and cleaner shutdown lifecycle.
- **Runtime behavior:** Prevents orphaned coroutines or hanging JVM processes in standalone environments.
- Lays groundwork for broader use of `TimeLogger` across lifecycle processes.

### Testing
- Manually tested standalone startup and shutdown via CLI commands (`stop`).
- Verified that all bootstrap steps log durations correctly in console.
- Ensured Spring cleanly exits with proper exit code via `exitProcess`.

### Additional Notes
- Could consider adding unit tests for `TimeLogger` or benchmark logging formats.
- May later expand `TimeLogger` to include tags, categories, or async step handling.
- Closes #40 