### PR TITLE
Fix error handling NPE

### DIFF
--- a/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/commands/CommandManagerImpl.kt
+++ b/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/commands/CommandManagerImpl.kt
@@ -115,7 +115,7 @@ class CommandManagerImpl {
         } catch (e: CommandSyntaxException) {
             source.sendFailure(buildText {
                 color(Colors.ERROR)
-                appendText(e.message!!)
+                appendText(e.message ?: e.javaClass.name)
                 clickEvent(ClickEvent.suggestCommand("/$label"))
             })
 


### PR DESCRIPTION
## Summary
- fix potential NullPointerException when displaying command parse errors

## Testing
- `./gradlew test` *(fails: could not complete due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_684039800b48832885c2d095ed7a1133