### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ https://chatgpt.com/g/g-67f7a61dc2208191bea4663d0771d6dd-flyway-migration-genera
     - [ ] codestyle settings (only for java if anyone would ever use that)
     - [ ] configure dokka
     - [ ] configure gitlab ci
-    - [ ] configure gitingore
+    - [ ] configure gitignore
     - [ ] basic project structure
 - [ ] Generators
     - [ ] packet id generator (one class where all packet ids are stored, annotated with @PacketIdStore)


### PR DESCRIPTION
## Summary
- fix gitingore typo in README

## Testing
- `./gradlew test` *(fails: Daemon will be stopped at the end of the build)*

------
https://chatgpt.com/codex/tasks/task_e_68403b1b27688328a9a406edd7e76238