### PR TITLE
Fix name of queue timeout registry

### DIFF
--- a/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/server/queue/timeout/ReentrantReadWriteLockQueueTimeoutRegistry.kt
+++ b/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/server/queue/timeout/ReentrantReadWriteLockQueueTimeoutRegistry.kt
@@ -11,7 +11,7 @@ import kotlin.concurrent.write
 
 
 @Component
-class ReentrantRedWriteLockQueueTimeoutRegistry : QueueTimeoutRegistry {
+class ReentrantReadWriteLockQueueTimeoutRegistry : QueueTimeoutRegistry {
     private val map = mutableObject2LongMapOf<UUID>().apply { defaultReturnValue(-1) }
     private val lock = ReentrantReadWriteLock()
 


### PR DESCRIPTION
## Summary
- rename `ReentrantRedWriteLockQueueTimeoutRegistry` to `ReentrantReadWriteLockQueueTimeoutRegistry`

## Testing
- `./gradlew test` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68403b2d2bcc832891573231ed6708a4