### PR TITLE
Fix typo in BukkitClientCloudPlayerImpl

### DIFF
--- a/surf-cloud-bukkit/src/main/kotlin/dev/slne/surf/cloud/bukkit/player/BukkitClientCloudPlayerImpl.kt
+++ b/surf-cloud-bukkit/src/main/kotlin/dev/slne/surf/cloud/bukkit/player/BukkitClientCloudPlayerImpl.kt
@@ -39,8 +39,8 @@ class BukkitClientCloudPlayerImpl(uuid: UUID, name: String) : ClientCloudPlayerI
         val player = audience ?: return
 
         val factory = ConversationFactory(plugin)
-        factory.withModality(true) // player dont receive messages from other players
-        factory.withLocalEcho(false) // player dont see their own messages
+        factory.withModality(true) // player doesn't receive messages from other players
+        factory.withLocalEcho(false) // player doesn't see their own messages
         factory.withPrefix { ">> " } // prefix for messages
         factory.withTimeout(60) // timeout in seconds
         factory.withEscapeSequence("exit") // escape sequence to exit conversation


### PR DESCRIPTION
## Summary
- fix typo in `BukkitClientCloudPlayerImpl` comments

## Testing
- `bash ./gradlew tasks` *(fails: Starting a Gradle Daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68403b37b64c8328ad6079672d68a65f