### PR TITLE
Add QueueEntryImpl compareTo tests

### DIFF
--- a/surf-cloud-standalone/build.gradle.kts
+++ b/surf-cloud-standalone/build.gradle.kts
@@ -31,6 +31,9 @@ dependencies {
             )
         }
     }
+
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.2")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.2")
 }
 
 tasks {
@@ -79,6 +82,10 @@ tasks {
                 requiredKeys.associateWith { migrationProperties.getProperty(it) }
             )
         }
+    }
+
+    test {
+        useJUnitPlatform()
     }
 }
 

--- a/surf-cloud-standalone/src/test/kotlin/dev/slne/surf/cloud/standalone/server/queue/QueueEntryImplTest.kt
+++ b/surf-cloud-standalone/src/test/kotlin/dev/slne/surf/cloud/standalone/server/queue/QueueEntryImplTest.kt
@@ -1,0 +1,46 @@
+package dev.slne.surf.cloud.standalone.server.queue
+
+import dev.slne.surf.cloud.standalone.server.queue.entry.PlayerQueueHandle
+import dev.slne.surf.cloud.standalone.server.queue.entry.QueueEntryImpl
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class QueueEntryImplTest {
+
+    private fun newEntry(priority: Int, preferredServer: Long? = null) =
+        QueueEntryImpl(
+            PlayerQueueHandle(UUID.randomUUID()),
+            priority,
+            bypassFull = false,
+            bypassQueue = false,
+            preferredServerUid = preferredServer
+        )
+
+    @Test
+    fun `compareTo honors priority`() {
+        val high = newEntry(priority = 10)
+        val low = newEntry(priority = 5)
+
+        assertEquals(-1, high.compareTo(low))
+        assertEquals(1, low.compareTo(high))
+    }
+
+    @Test
+    fun `compareTo prioritizes preferred server`() {
+        val a = newEntry(priority = 5, preferredServer = 1)
+        val b = newEntry(priority = 5, preferredServer = null)
+
+        assertEquals(-1, a.compareTo(b))
+        assertEquals(1, b.compareTo(a))
+    }
+
+    @Test
+    fun `compareTo equality when all fields equal`() {
+        val a = newEntry(priority = 5, preferredServer = 1)
+        val b = QueueEntryImpl(a.handle, 5, false, false, 1)
+
+        assertEquals(0, a.compareTo(b))
+        assertEquals(0, b.compareTo(a))
+    }
+}


### PR DESCRIPTION
## Summary
- add junit dependencies and enable junit platform
- write unit tests for QueueEntryImpl.compareTo

## Testing
- `./gradlew :surf-cloud-standalone:test --no-daemon` *(fails: Could not finish due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68403b3ca2a88328988d24162681b2fd