### PR TITLE
feat: add sorting option for playtime retrieval methods

### DIFF
--- a/surf-cloud-api/surf-cloud-api-common/src/main/kotlin/dev/slne/surf/cloud/api/common/player/playtime/Playtime.kt
+++ b/surf-cloud-api/surf-cloud-api-common/src/main/kotlin/dev/slne/surf/cloud/api/common/player/playtime/Playtime.kt
@@ -88,7 +88,7 @@ interface Playtime {
      * @param since Optional start time to filter playtime.
      * @return An [Object2ObjectMap] where keys are server names and values are durations.
      */
-    fun playtimesPerServer(since: ZonedDateTime? = null): Object2ObjectMap<String, Duration>
+    fun playtimesPerServer(since: ZonedDateTime? = null, sortByPlaytime: Boolean = false): Object2ObjectMap<String, Duration>
 
     /**
      * Returns a mapping of categories to their respective total playtime durations.
@@ -96,9 +96,9 @@ interface Playtime {
      * @param since Optional start time to filter playtime.
      * @return An [Object2ObjectMap] where keys are category names and values are durations.
      */
-    fun playtimesPerCategory(since: ZonedDateTime? = null): Object2ObjectMap<String, Duration>
+    fun playtimesPerCategory(since: ZonedDateTime? = null, sortByPlaytime: Boolean = false): Object2ObjectMap<String, Duration>
 
-    fun playtimePerCategoryPerServer(since: ZonedDateTime? = null): Object2ObjectMap<String, Object2ObjectMap<String, Duration>>
+    fun playtimePerCategoryPerServer(since: ZonedDateTime? = null, sortByPlaytime: Boolean = false): Object2ObjectMap<String, Object2ObjectMap<String, Duration>>
 
     /**
      * Returns the average playtime per server, optionally filtered by category and start time.
@@ -167,7 +167,7 @@ interface Playtime {
      * @param since Optional start time to filter playtime.
      * @return An [ObjectList] of pairs, each containing a server name and its corresponding playtime duration.
      */
-    fun topServers(limit: Int = 5, since: ZonedDateTime? = null): ObjectList<Pair<String, Duration>>
+    fun topServers(limit: Int = 5, since: ZonedDateTime? = null, sortByPlaytime: Boolean = false): ObjectList<Pair<String, Duration>>
 
     /**
      * Retrieves a ranked list of categories sorted by total playtime in descending order.
@@ -176,7 +176,7 @@ interface Playtime {
      * @param since Optional start time to filter playtime.
      * @return An [ObjectList] of pairs, each containing a category name and its corresponding playtime duration.
      */
-    fun topCategories(limit: Int = 5, since: ZonedDateTime? = null): ObjectList<Pair<String, Duration>>
+    fun topCategories(limit: Int = 5, since: ZonedDateTime? = null, sortByPlaytime: Boolean = false): ObjectList<Pair<String, Duration>>
 
     fun writeToByteBuf(buf: ByteBuf)
 }

--- a/surf-cloud-api/surf-cloud-api-common/src/main/kotlin/dev/slne/surf/cloud/api/common/player/playtime/Playtime.kt
+++ b/surf-cloud-api/surf-cloud-api-common/src/main/kotlin/dev/slne/surf/cloud/api/common/player/playtime/Playtime.kt
@@ -167,7 +167,7 @@ interface Playtime {
      * @param since Optional start time to filter playtime.
      * @return An [ObjectList] of pairs, each containing a server name and its corresponding playtime duration.
      */
-    fun topServers(limit: Int = 5, since: ZonedDateTime? = null, sortByPlaytime: Boolean = true): ObjectList<Pair<String, Duration>>
+    fun topServers(limit: Int = 5, since: ZonedDateTime? = null): ObjectList<Pair<String, Duration>>
 
     /**
      * Retrieves a ranked list of categories sorted by total playtime in descending order.
@@ -176,7 +176,7 @@ interface Playtime {
      * @param since Optional start time to filter playtime.
      * @return An [ObjectList] of pairs, each containing a category name and its corresponding playtime duration.
      */
-    fun topCategories(limit: Int = 5, since: ZonedDateTime? = null, sortByPlaytime: Boolean = true): ObjectList<Pair<String, Duration>>
+    fun topCategories(limit: Int = 5, since: ZonedDateTime? = null): ObjectList<Pair<String, Duration>>
 
     fun writeToByteBuf(buf: ByteBuf)
 }

--- a/surf-cloud-api/surf-cloud-api-common/src/main/kotlin/dev/slne/surf/cloud/api/common/player/playtime/Playtime.kt
+++ b/surf-cloud-api/surf-cloud-api-common/src/main/kotlin/dev/slne/surf/cloud/api/common/player/playtime/Playtime.kt
@@ -88,7 +88,7 @@ interface Playtime {
      * @param since Optional start time to filter playtime.
      * @return An [Object2ObjectMap] where keys are server names and values are durations.
      */
-    fun playtimesPerServer(since: ZonedDateTime? = null, sortByPlaytime: Boolean = false): Object2ObjectMap<String, Duration>
+    fun playtimesPerServer(since: ZonedDateTime? = null, sortByPlaytime: Boolean = true): Object2ObjectMap<String, Duration>
 
     /**
      * Returns a mapping of categories to their respective total playtime durations.
@@ -96,9 +96,9 @@ interface Playtime {
      * @param since Optional start time to filter playtime.
      * @return An [Object2ObjectMap] where keys are category names and values are durations.
      */
-    fun playtimesPerCategory(since: ZonedDateTime? = null, sortByPlaytime: Boolean = false): Object2ObjectMap<String, Duration>
+    fun playtimesPerCategory(since: ZonedDateTime? = null, sortByPlaytime: Boolean = true): Object2ObjectMap<String, Duration>
 
-    fun playtimePerCategoryPerServer(since: ZonedDateTime? = null, sortByPlaytime: Boolean = false): Object2ObjectMap<String, Object2ObjectMap<String, Duration>>
+    fun playtimePerCategoryPerServer(since: ZonedDateTime? = null, sortByPlaytime: Boolean = true): Object2ObjectMap<String, Object2ObjectMap<String, Duration>>
 
     /**
      * Returns the average playtime per server, optionally filtered by category and start time.
@@ -167,7 +167,7 @@ interface Playtime {
      * @param since Optional start time to filter playtime.
      * @return An [ObjectList] of pairs, each containing a server name and its corresponding playtime duration.
      */
-    fun topServers(limit: Int = 5, since: ZonedDateTime? = null, sortByPlaytime: Boolean = false): ObjectList<Pair<String, Duration>>
+    fun topServers(limit: Int = 5, since: ZonedDateTime? = null, sortByPlaytime: Boolean = true): ObjectList<Pair<String, Duration>>
 
     /**
      * Retrieves a ranked list of categories sorted by total playtime in descending order.
@@ -176,7 +176,7 @@ interface Playtime {
      * @param since Optional start time to filter playtime.
      * @return An [ObjectList] of pairs, each containing a category name and its corresponding playtime duration.
      */
-    fun topCategories(limit: Int = 5, since: ZonedDateTime? = null, sortByPlaytime: Boolean = false): ObjectList<Pair<String, Duration>>
+    fun topCategories(limit: Int = 5, since: ZonedDateTime? = null, sortByPlaytime: Boolean = true): ObjectList<Pair<String, Duration>>
 
     fun writeToByteBuf(buf: ByteBuf)
 }

--- a/surf-cloud-bukkit/src/main/kotlin/dev/slne/surf/cloud/bukkit/command/playtime/PlaytimeCommand.kt
+++ b/surf-cloud-bukkit/src/main/kotlin/dev/slne/surf/cloud/bukkit/command/playtime/PlaytimeCommand.kt
@@ -39,7 +39,7 @@ private fun sendPlaytime(sender: CommandSender, player: OfflineCloudPlayer) = pl
         variableValue("${player.name()} (${player.uuid})")
         appendNewPrefixedLine()
         appendNewPrefixedLine {
-            variableKey("Total")
+            variableKey("Gesamt")
             spacer(": ")
             variableValue(complete.toString())
         }

--- a/surf-cloud-core/surf-cloud-core-common/src/main/kotlin/dev/slne/surf/cloud/core/common/player/playtime/PlaytimeImpl.kt
+++ b/surf-cloud-core/surf-cloud-core-common/src/main/kotlin/dev/slne/surf/cloud/core/common/player/playtime/PlaytimeImpl.kt
@@ -103,7 +103,7 @@ class PlaytimeImpl(private val entries: ObjectList<PlaytimeEntry>) : Playtime {
         since: ZonedDateTime?,
         sortByPlaytime: Boolean
     ): Object2ObjectMap<String, Object2ObjectMap<String, Duration>> {
-        val filtered = entries.asSequence()
+        val filtered = entries
             .filter { since == null || it.createdAt.isAfter(since) }
 
         val grouped = filtered.groupBy { it.category }

--- a/surf-cloud-core/surf-cloud-core-common/src/main/kotlin/dev/slne/surf/cloud/core/common/player/playtime/PlaytimeImpl.kt
+++ b/surf-cloud-core/surf-cloud-core-common/src/main/kotlin/dev/slne/surf/cloud/core/common/player/playtime/PlaytimeImpl.kt
@@ -172,8 +172,7 @@ class PlaytimeImpl(private val entries: ObjectList<PlaytimeEntry>) : Playtime {
 
     override fun topServers(
         limit: Int,
-        since: ZonedDateTime?,
-        sortByPlaytime: Boolean
+        since: ZonedDateTime?
     ): ObjectList<Pair<String, Duration>> = entries
         .filter { since == null || it.createdAt.isAfter(since) }
         .groupBy { it.server }
@@ -185,8 +184,7 @@ class PlaytimeImpl(private val entries: ObjectList<PlaytimeEntry>) : Playtime {
 
     override fun topCategories(
         limit: Int,
-        since: ZonedDateTime?,
-        sortByPlaytime: Boolean
+        since: ZonedDateTime?
     ): ObjectList<Pair<String, Duration>> = entries
         .filter { since == null || it.createdAt.isAfter(since) }
         .groupBy { it.category }

--- a/surf-cloud-core/surf-cloud-core-common/src/main/kotlin/dev/slne/surf/cloud/core/common/player/playtime/PlaytimeImpl.kt
+++ b/surf-cloud-core/surf-cloud-core-common/src/main/kotlin/dev/slne/surf/cloud/core/common/player/playtime/PlaytimeImpl.kt
@@ -122,8 +122,12 @@ class PlaytimeImpl(private val entries: ObjectList<PlaytimeEntry>) : Playtime {
                 }
             }
 
+        val categorySums = grouped.mapValues { (_, serverDurations) ->
+            serverDurations.values.sumOf { it.inWholeSeconds }
+        }
+
         val finalResult = if (sortByPlaytime)
-            grouped.entries.sortedByDescending { it.value.values.sumOf { it.inWholeSeconds } }
+            grouped.entries.sortedByDescending { categorySums[it.key] }
         else grouped.entries
 
         return mutableObject2ObjectMapOf<String, Object2ObjectMap<String, Duration>>().apply {


### PR DESCRIPTION
This pull request introduces a new feature to the `Playtime` interface and its implementation, allowing playtime data to be optionally sorted by duration. Additionally, it includes a minor localization change in the `PlaytimeCommand`. Below is a summary of the most important changes:

### Feature: Sorting Playtime Data by Duration
* **`surf-cloud-api-common/src/main/kotlin/dev/slne/surf/cloud/api/common/player/playtime/Playtime.kt`:** Updated methods in the `Playtime` interface (`playtimesPerServer`, `playtimesPerCategory`, `playtimePerCategoryPerServer`, `topServers`, and `topCategories`) to include an optional `sortByPlaytime` parameter for sorting results by playtime duration. [[1]](diffhunk://#diff-fe30ef8494e0c2cbaab4111e2c27ef2348a60de73d4e504489e12ea5aeee7917L91-R101) [[2]](diffhunk://#diff-fe30ef8494e0c2cbaab4111e2c27ef2348a60de73d4e504489e12ea5aeee7917L170-R170) [[3]](diffhunk://#diff-fe30ef8494e0c2cbaab4111e2c27ef2348a60de73d4e504489e12ea5aeee7917L179-R179)
* **`surf-cloud-core-common/src/main/kotlin/dev/slne/surf/cloud/core/common/player/playtime/PlaytimeImpl.kt`:** Implemented the `sortByPlaytime` parameter in the corresponding methods, enabling sorting of playtime data at different levels (server, category, and category-per-server). The sorting logic was added for both individual and grouped results. [[1]](diffhunk://#diff-04d61b2c05c0d249c0a910556add3652f2e77fd9ecc67632005e5da7bdb7e884L64-R137) [[2]](diffhunk://#diff-04d61b2c05c0d249c0a910556add3652f2e77fd9ecc67632005e5da7bdb7e884L126-R176) [[3]](diffhunk://#diff-04d61b2c05c0d249c0a910556add3652f2e77fd9ecc67632005e5da7bdb7e884L138-R189)

### Localization Improvement
* **`surf-cloud-bukkit/src/main/kotlin/dev/slne/surf/cloud/bukkit/command/playtime/PlaytimeCommand.kt`:** Changed the label for "Total" playtime to "Gesamt" in the `sendPlaytime` method for better localization.

fixes #83 