### PR TITLE
Correct Table Usage

### DIFF
--- a/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/GenerateExposedMigrationScript.kt
+++ b/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/GenerateExposedMigrationScript.kt
@@ -16,6 +16,6 @@ fun main() {
         MutePunishmentNoteTable,
         WarnPunishmentNoteTable,
         WhitelistTable,
-        scriptName = "V7__add_whitelist_table",
+        scriptName = "V8__change_tables_add_cloud_player_references",
     )
 }

--- a/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/player/db/exposed/CloudPlayerTables.kt
+++ b/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/player/db/exposed/CloudPlayerTables.kt
@@ -7,7 +7,7 @@ import dev.slne.surf.cloud.api.server.exposed.table.AuditableLongIdTable
 import org.jetbrains.exposed.sql.ReferenceOption
 import java.net.Inet4Address
 
-object CloudPlayerTable : AuditableLongIdTable("cloud_player") {
+object CloudPlayerTable : AuditableLongIdTable("cloud_players") {
     val uuid = nativeUuid("uuid").uniqueIndex()
     val lastServer = char("last_server", 255).nullable()
     val lastSeen = zonedDateTime("last_seen").nullable()
@@ -19,7 +19,7 @@ object CloudPlayerTable : AuditableLongIdTable("cloud_player") {
         .nullable()
 }
 
-object CloudPlayerNameHistoryTable : AuditableLongIdTable("cloud_player_name_history") {
+object CloudPlayerNameHistoryTable : AuditableLongIdTable("cloud_player_name_histories") {
     val name = char("name", 16)
     val player = reference(
         "cloud_player_id",

--- a/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/player/db/exposed/punishment/table/AbstractPunishmentTable.kt
+++ b/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/player/db/exposed/punishment/table/AbstractPunishmentTable.kt
@@ -5,11 +5,23 @@ import dev.slne.surf.cloud.api.server.exposed.table.AuditableLongIdTable
 
 abstract class AbstractPunishmentTable(name: String) : AuditableLongIdTable(name) {
     val punishmentId = char("punishment_id", 8).uniqueIndex()
-    val punishedUuid = nativeUuid("punished_uuid")
-    val issuerUuid = nativeUuid("issuer_uuid").nullable()
+    val parentPunishment = reference(
+        "parent_punishment_id",
+        this,
+        onDelete = ReferenceOption.CASCADE,
+        onUpdate = ReferenceOption.CASCADE
+    ).nullable()
+    val punishedPlayer = reference(
+        "cloud_player_id",
+        CloudPlayerTable,
+        onDelete = ReferenceOption.CASCADE,
+        onUpdate = ReferenceOption.CASCADE
+    )
+    val issuerPlayer = reference(
+        "issuer_id",
+        CloudPlayerTable,
+        onDelete = ReferenceOption.SET_NULL,
+        onUpdate = ReferenceOption.SET_NULL
+    ).nullable()
     val reason = largeText("reason").nullable()
-
-    init {
-        index("idx_punished_uuid", false, punishedUuid)
-    }
 }

--- a/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/player/db/exposed/punishment/table/AbstractUnpunishableExpirablePunishmentTable.kt
+++ b/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/player/db/exposed/punishment/table/AbstractUnpunishableExpirablePunishmentTable.kt
@@ -7,7 +7,12 @@ abstract class AbstractUnpunishableExpirablePunishmentTable(name: String) :
     AbstractPunishmentTable(name) {
     val unpunished = bool("unpunished").default(false)
     val unpunishedDate = zonedDateTime("unpunished_date").nullable().default(null)
-    val unpunisherUuid = nativeUuid("unpunisher_uuid").nullable().default(null)
+    val unpunisherPlayer = reference(
+        "unpunisher_id",
+        CloudPlayerTable,
+        onDelete = ReferenceOption.CASCADE,
+        onUpdate = ReferenceOption.CASCADE
+    ).nullable().default(null)
     val expirationDate = zonedDateTime("expiration_date").nullable().default(null)
     val permanent = bool("permanent").default(false)
 

--- a/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/player/db/exposed/whitelist/WhitelistTable.kt
+++ b/surf-cloud-standalone/src/main/kotlin/dev/slne/surf/cloud/standalone/player/db/exposed/whitelist/WhitelistTable.kt
@@ -7,8 +7,7 @@ import org.jetbrains.exposed.sql.ReferenceOption
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.or
 
-object WhitelistTable : AuditableLongIdTable("whitelist") {
-    val uuid = nativeUuid("uuid").index()
+object WhitelistTable : AuditableLongIdTable("whitelists") {
     val blocked = bool("blocked").default(false)
     val group = varchar("group", 255).nullable()
     val serverName = varchar("server_name", 255).nullable()
@@ -25,6 +24,6 @@ object WhitelistTable : AuditableLongIdTable("whitelist") {
         }
 
         uniqueIndex(uuid, group)
-        uniqueIndex(uuid, serverName,)
+        uniqueIndex(uuid, serverName)
     }
 }


### PR DESCRIPTION
This pull request updates the database schema and related code to improve referential integrity and consistency in table naming. The main changes include updating table names to be plural, replacing UUID fields with foreign key references to the `CloudPlayerTable`, and updating migration script naming.

**Database schema improvements:**

* Changed several table names to use plural forms for consistency (`cloud_player` → `cloud_players`, `cloud_player_name_history` → `cloud_player_name_histories`, `whitelist` → `whitelists`). [[1]](diffhunk://#diff-8598658ae74554ce6777adae944d3008a2adf2f72b5f0826d7f1fe569153f57cL10-R10) [[2]](diffhunk://#diff-8598658ae74554ce6777adae944d3008a2adf2f72b5f0826d7f1fe569153f57cL22-R22) [[3]](diffhunk://#diff-30fd674be326efa5ff7422b14e4c97e9a45a463763e450fc3c9b3d744df46458L10-R10)
* Updated `AbstractPunishmentTable` to replace `punishedUuid` and `issuerUuid` fields with foreign key references to `CloudPlayerTable`, and added a `parentPunishment` self-reference for hierarchical punishments.
* Updated `AbstractUnpunishableExpirablePunishmentTable` to replace `unpunisherUuid` with a foreign key reference to `CloudPlayerTable`.

**Migration and index changes:**

* Updated the migration script name to reflect the new changes: `V8__change_tables_add_cloud_player_references`.
* Fixed a minor typo in the unique index definition in `WhitelistTable`.