### PR TITLE
feat: introduce `AfkStateChangeEvent` for AFK state tracking

### DIFF
--- a/surf-cloud-api/surf-cloud-api-common/src/main/kotlin/dev/slne/surf/cloud/api/common/event/player/afk/AfkStateChangeEvent.kt
+++ b/surf-cloud-api/surf-cloud-api-common/src/main/kotlin/dev/slne/surf/cloud/api/common/event/player/afk/AfkStateChangeEvent.kt
@@ -1,0 +1,7 @@
+package dev.slne.surf.cloud.api.common.event.player.afk
+
+import dev.slne.surf.cloud.api.common.event.player.CloudPlayerEvent
+import dev.slne.surf.cloud.api.common.player.CloudPlayer
+
+class AfkStateChangeEvent(val isAfk: Boolean, source: Any, player: CloudPlayer) :
+    CloudPlayerEvent(source, player)

--- a/surf-cloud-core/surf-cloud-core-client/src/main/kotlin/dev/slne/surf/cloud/core/client/netty/network/ClientRunningPacketListenerImpl.kt
+++ b/surf-cloud-core/surf-cloud-core-client/src/main/kotlin/dev/slne/surf/cloud/core/client/netty/network/ClientRunningPacketListenerImpl.kt
@@ -3,6 +3,7 @@ package dev.slne.surf.cloud.core.client.netty.network
 import com.google.common.flogger.StackSize
 import dev.slne.surf.cloud.api.common.event.offlineplayer.punishment.CloudPlayerPunishEvent
 import dev.slne.surf.cloud.api.common.event.offlineplayer.punishment.CloudPlayerPunishmentUpdatedEvent
+import dev.slne.surf.cloud.api.common.event.player.afk.AfkStateChangeEvent
 import dev.slne.surf.cloud.api.common.netty.network.ConnectionProtocol
 import dev.slne.surf.cloud.api.common.netty.network.protocol.respond
 import dev.slne.surf.cloud.api.common.netty.packet.NettyPacket
@@ -274,6 +275,7 @@ class ClientRunningPacketListenerImpl(
         playerManagerImpl.getPlayer(packet.uuid)?.let { player ->
             require(player is ClientCloudPlayerImpl<*>) { "Player $player is not a client player" }
             player.afk = packet.isAfk
+            AfkStateChangeEvent(packet.isAfk, this, player).postAndForget()
         }
     }
 


### PR DESCRIPTION
- Added `AfkStateChangeEvent` to track player AFK state changes.
- Updated player implementation to use `AtomicBoolean` for thread-safe AFK state management.
- Integrated `AfkStateChangeEvent` posting in AFK state update logic across client and standalone modules.